### PR TITLE
Fix correctness issues raised in PR #17 review

### DIFF
--- a/pfeiffer/PfeifferVacuumCommunication.py
+++ b/pfeiffer/PfeifferVacuumCommunication.py
@@ -73,13 +73,10 @@ class MaxiGauge:
                     retry_count += 1
                     print('...connection refused, at',time.ctime(),' Is motor_server process running on remote machine?',
                             '  Retry', retry_count, '/', RETRIES, "on", str(self.ip_addr))
-                except TimeoutError:
-                    retry_count += 1
-                    print('...connection attempt timed out, at',time.ctime(),
-                            '  Retry', retry_count, '/', RETRIES, "on", str(self.ip_addr))
-                    time.sleep(0.5) #05/08/2025
-                    raise
-                except socket.timeout: #05/08/2025
+                except (TimeoutError, socket.timeout):
+                    # In Python 3.10+ socket.timeout is an alias for TimeoutError;
+                    # one handler covers both. Retry rather than re-raising so the
+                    # RETRIES budget is honored.
                     retry_count += 1
                     print('...connection attempt timed out, at',time.ctime(),
                             '  Retry', retry_count, '/', RETRIES, "on", str(self.ip_addr))
@@ -225,7 +222,7 @@ class MaxiGauge:
                 return gas_type
             except Exception as e:
                 if attempt == retries -1:
-                    raise MaxiGaugeError(f"Gas type retrieval faileda after {retries} attempts: {e}")
+                    raise MaxiGaugeError(f"Gas type retrieval failed after {retries} attempts: {e}")
                 time.sleep(0.2)
 
 

--- a/pfeiffer/Pfeiffer_GUI.py
+++ b/pfeiffer/Pfeiffer_GUI.py
@@ -22,7 +22,6 @@ os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 
 import numpy as np
 import h5py
-import os
 import time
 import datetime
 
@@ -101,7 +100,7 @@ class Worker(QObject):
                     print("File temporarily locked by writer. Retry in 1s...")
                 else:
                     print(f"HDF5 read error: {e}")
-                QThread.msleep(20)
+                QThread.msleep(1000)
 
 
 

--- a/pfeiffer/Pfeiffer_control.py
+++ b/pfeiffer/Pfeiffer_control.py
@@ -21,6 +21,9 @@ from PfeifferVacuumCommunication import MaxiGauge, MaxiGaugeError #updated by Ji
 #===CHANGE THE FOLLOWING PARAMETERS IF NECCESSARY=================================================================================================
 ip_address = "192.168.7.44"
 hdf5_path = r"C:\data\gauge"
+# h5clear executable: prefer PATH, fall back to vendored install location on the lab PC
+H5CLEAR_CMD = "h5clear"
+H5CLEAR_FALLBACK = r"C:/Program Files/HDF_Group/HDF5/1.14.6/bin/h5clear.exe"
 #===============================================================================================================================================
 #===============================================================================================================================================
 
@@ -163,10 +166,18 @@ def log_connection_event(event_time, status, log_dir="C:\\data\\gauge", error_me
 
 #===============================================================================================================================================
 
+def run_h5clear(target):
+	"""Run h5clear on a file, trying PATH first then the fallback install path."""
+	try:
+		subprocess.run([H5CLEAR_CMD, "-s", target], check=True)
+	except (FileNotFoundError, subprocess.CalledProcessError):
+		subprocess.run([H5CLEAR_FALLBACK, "-s", target], check=True)
+
 def main():
 
 	pfController = MaxiGauge(ip_addr=ip_address)
-	count = 0 
+	count = 0
+	f = None  # ensure name exists for outer except handler before first open
 	date = datetime.date.today()
 	hdf5_ifn = f"{hdf5_path}\\pressure_data_{date}.hdf5"
 
@@ -179,12 +190,12 @@ def main():
 		if "SWMR" in str(e) or "already open for write" in str(e):
 			print("SWMR lock detected during init. Attempting h5clear recovery...")
 			try:
-				subprocess.run(["h5clear", "-s", hdf5_ifn], check=True)
+				run_h5clear(hdf5_ifn)
 				print("h5clear succeeded. Retrying init_hdf5_file...")
 				init_hdf5_file(hdf5_ifn, pfController)
-			except subprocess.CalledProcessError as h5clear_err:
+			except (subprocess.CalledProcessError, FileNotFoundError) as h5clear_err:
 				print("h5clear failed during init:", h5clear_err)
-				return  
+				return
 		else:
 			raise  
 
@@ -269,13 +280,13 @@ def main():
 			if "SWMR" in str(e) or "already open for write" in str(e):
 				print("Detected SWMR lock. Attempting auto-recovery using h5clear...")
 				try:
-					subprocess.run(["C:/Program Files/HDF_Group/HDF5/1.14.6/bin/h5clear.exe", "-s", hdf5_ifn], check=True) #update 5/1
+					run_h5clear(hdf5_ifn)
 					print("h5clear completed successfully. Retrying...")
 					time.sleep(2)
-					continue  
-				except subprocess.CalledProcessError as h5clear_err:
+					continue
+				except (subprocess.CalledProcessError, FileNotFoundError) as h5clear_err:
 					print("h5clear failed:", h5clear_err)
-					break 
+					break
 			else:
 				print("Unable to open HDF5 file. Retrying...")
 				time.sleep(0.01)


### PR DESCRIPTION
## Summary

Targets `jingxuanxu04-final-version` so these fixes land inside PR #17 before it merges to `main`. Addresses the must-fix correctness items from the review of #17:

- **`PfeifferVacuumCommunication.connect`** — the `TimeoutError` handler had a `raise` that defeated the `RETRIES = 300` loop on the very first timeout. On Python 3.10+ `socket.timeout` is an alias for `TimeoutError`, so the sibling handler was unreachable anyway. Merged into one handler that retries.
- **`PfeifferVacuumCommunication.get_gas_type`** — typo: `"faileda after"` → `"failed after"`.
- **`Pfeiffer_control.main`** — `f` was referenced in the outer `except Exception` (`if f is not None`) but only bound inside the inner `try`. A failure before the first successful `h5py.File(...)` open would raise `UnboundLocalError`. Initialize `f = None` before the loop.
- **`Pfeiffer_control`** — the SWMR-recovery path used bare `"h5clear"` at init but a hard-coded `C:/Program Files/HDF_Group/HDF5/1.14.6/bin/h5clear.exe` in the main loop. Extracted `run_h5clear()` that tries `PATH` first and falls back to the vendored install location.
- **`Pfeiffer_GUI`** — duplicate `import os`; removed.
- **`Pfeiffer_GUI.Worker.run`** — error-path back-off was reduced from 1 s to 20 ms, which polls a writer-locked file 50x/sec. Restored to 1 s.

## Items deliberately left for the original author

- The `'\x06' in test or "ACK" in test` guard in `get_all_pressure_reading` — needs protocol confirmation; not changed here.
- `os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"` in the GUI — may be a deliberate Windows workaround for SWMR-on-Windows; left in place but worth a comment justifying it.
- Cosmetic dated/author-tag comments — left alone since they're not the focus here.
- Squash-merge of the 25-commit history into `main` — recommended at the final merge step.

## Test plan

- [ ] `python -m py_compile` on all three files (passes locally)
- [ ] On the lab PC with the gauge attached: confirm `connect()` retries on a wrong/down IP for several attempts instead of raising on the first timeout
- [ ] Confirm `Pfeiffer_control.main` no longer crashes with `UnboundLocalError` if the very first HDF5 open fails
- [ ] Confirm GUI startup still reads pressure data and updates both panels

Generated with Claude Code.
